### PR TITLE
Fix issues with running MNIST example and example-img.ipynb

### DIFF
--- a/example-img.ipynb
+++ b/example-img.ipynb
@@ -263,7 +263,7 @@
     "img = all_imgs[1]\n",
     "\n",
     "# Define a random mask\n",
-    "context_mask = torch.Tensor(32, 32).uniform_() > 0.9\n",
+    "context_mask = (torch.Tensor(32, 32).uniform_() > 0.9).byte()\n",
     "\n",
     "# Visualize occluded image\n",
     "occluded_img = img * context_mask.float()\n",

--- a/trained_models/mnist/config.json
+++ b/trained_models/mnist/config.json
@@ -1,1 +1,1 @@
-{"img_size": [1, 28, 28], "h_dim": 256, "num_context_range": [3, 200], "z_dim": 256, "batch_size": 16, "epochs": 100, "r_dim": 256, "lr": 5e-05, "num_extra_target_range": [0, 200]}
+{"dataset": "mnist", "img_size": [1, 28, 28], "h_dim": 256, "num_context_range": [3, 200], "z_dim": 256, "batch_size": 16, "epochs": 100, "r_dim": 256, "lr": 5e-05, "num_extra_target_range": [0, 200]}


### PR DESCRIPTION
The config.json for the trained MNIST model is missing the dataset field, which causes a crash when trying to recreate the MNIST example from the CLI.

Additionally, `context_mask = torch.Tensor(32, 32).uniform_() > 0.9` in `example-img.ipynb` creates a boolean Tensor, which causes a crash when trying to run the notebook (can't use boolean Tensors to subtract) - adding a `.byte()` conversion fixes this and allows the notebook to be run without any problems.
